### PR TITLE
changes done to support promise Version ^ 7.0

### DIFF
--- a/lib/fusioncharts2svg-spawner.js
+++ b/lib/fusioncharts2svg-spawner.js
@@ -17,17 +17,25 @@ function makeTmpDirectory() {
 }
 
 function spawnConverterFromFile(dataSourceFile) {
-  const command = `${phantomBinPath} ${path.join(__dirname, '../bin/fusioncharts2svg.js')} ${dataSourceFile}`;
+ const command = `${phantomBinPath} ${path.join(__dirname, '../bin/fusioncharts2svg.js')} ${dataSourceFile}`;
 
-  const deferred = Promise.defer();
-  exec(command, { maxBuffer: maxBuffer }, (err, stdout, stderr) => {
-    if (err) deferred.reject(err);
-    else if (stderr) deferred.reject(stderr);
+ var promise = new Promise(function (resolve, reject) {
+   exec(command, { maxBuffer: maxBuffer },  function (err, stdout, stderr) {
+     if (err) reject(err);
+     else if(stderr) reject(stderr);
+     else resolve(stdout);
+   });
+ });
 
-    deferred.resolve(stdout);
-  });
+ //const deferred = Promise.defer();
+ //exec(command, { maxBuffer: maxBuffer }, (err, stdout, stderr) => {
+ //  if (err) deferred.reject(err);
+ //  else if (stderr) deferred.reject(stderr);
+ //
+ //  deferred.resolve(stdout);
+ //});
 
-  return deferred.promise;
+ return promise;
 }
 
 function spawnConverterFromObject(dataSource) {


### PR DESCRIPTION
Would work with new promise versions.
Promise.defer() was deprecated earlier.
